### PR TITLE
Changed the linear gradient import to reflect Expo SDK v33 requirements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "expo-hsv-color-picker",
+  "version": "0.0.3",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "expo-linear-gradient": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/expo-linear-gradient/-/expo-linear-gradient-6.0.0.tgz",
+      "integrity": "sha512-TGHSK7MsoU1wZXx9uEivMggAR/KT4wTSE0xBfhB8qsziGXoHZdoT79/tZ3HyWtCG7+JVUEFXfUOBxtOlZOu5tg=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   ],
   "dependencies": {
     "chroma-js": "^2.0.3",
+    "expo-linear-gradient": "^6.0.0",
     "prop-types": "15.6.0"
   },
   "devDependencies": {

--- a/src/HuePicker.js
+++ b/src/HuePicker.js
@@ -6,7 +6,7 @@ import {
   PanResponder,
   StyleSheet,
 } from 'react-native';
-import { LinearGradient } from 'expo';
+import { LinearGradient } from 'expo-linear-gradient';
 import PropTypes from 'prop-types';
 import chroma from 'chroma-js';
 import normalizeValue from './utils';

--- a/src/SaturationValuePicker.js
+++ b/src/SaturationValuePicker.js
@@ -6,7 +6,7 @@ import {
   PanResponder,
   StyleSheet,
 } from 'react-native';
-import { LinearGradient } from 'expo';
+import { LinearGradient } from 'expo-linear-gradient';
 import PropTypes from 'prop-types';
 import chroma from 'chroma-js';
 import normalizeValue from './utils';


### PR DESCRIPTION
Hi There! I changed the linear gradient import to reflect Expo SDK v33 requirements, and also added expo-linear-gradient (needed now for linear gradients) to dependencies in package.json. Please have a look and merge if you would like. Any questions feel free to reach out! 

https://forums.expo.io/t/importing-lineargradient-deprecation-warning-after-upgrading-to-sdk-33/23537

https://docs.expo.io/versions/latest/sdk/linear-gradient/